### PR TITLE
Support option XMLResource.OPTION_RESOLVE_ENTITIES

### DIFF
--- a/features/org.eclipse.emf.ecore-feature/feature.xml
+++ b/features/org.eclipse.emf.ecore-feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.emf.ecore"
       label="%featureName"
-      version="2.33.0.qualifier"
+      version="2.35.0.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.emf.license"
       license-feature-version="2.11.0">

--- a/features/org.eclipse.emf.ecore-feature/pom.xml
+++ b/features/org.eclipse.emf.ecore-feature/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>org.eclipse.emf.features</groupId>
   <artifactId>org.eclipse.emf.ecore</artifactId>
-  <version>2.33.0-SNAPSHOT</version>
+  <version>2.35.0-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 
 </project>

--- a/plugins/org.eclipse.emf.codegen.ecore/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.codegen.ecore/META-INF/MANIFEST.MF
@@ -25,7 +25,7 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.9.0,4.0.0)",
  org.eclipse.jdt.launching;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.emf.ecore;bundle-version="[2.35.0,3.0.0)";visibility:=reexport,
  org.eclipse.emf.codegen;bundle-version="[2.23.0,3.0.0)";visibility:=reexport,
- org.eclipse.emf.ecore.xmi;bundle-version="[2.18.0,3.0.0)",
+ org.eclipse.emf.ecore.xmi;bundle-version="[2.35.0,3.0.0)",
  org.eclipse.text;bundle-version="[3.5.0,4.0.0)"
 Provide-Capability: org.eclipse.emf.ecore.generated_package;uri="http://www.eclipse.org/emf/2002/GenModel";class=org.eclipse.emf.codegen.ecore.genmodel.GenModelPackage;genModel="model/GenModel.genmodel"
 Bundle-ActivationPolicy: lazy

--- a/plugins/org.eclipse.emf.ecore.xmi/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.ecore.xmi/META-INF/MANIFEST.MF
@@ -2,17 +2,17 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.emf.ecore.xmi; singleton:=true
-Bundle-Version: 2.18.0.qualifier
+Bundle-Version: 2.35.0.qualifier
 Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.emf.ecore.xmi.XMIPlugin$Implementation$Activator
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
-Export-Package: org.eclipse.emf.ecore.xmi;version="2.18.0",
- org.eclipse.emf.ecore.xmi.impl;version="2.18.0",
- org.eclipse.emf.ecore.xmi.util;version="2.18.0"
+Export-Package: org.eclipse.emf.ecore.xmi;version="2.35.0",
+ org.eclipse.emf.ecore.xmi.impl;version="2.35.0",
+ org.eclipse.emf.ecore.xmi.util;version="2.35.0"
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.9.0,4.0.0)";resolution:=optional;x-installation:=greedy,
- org.eclipse.emf.ecore;bundle-version="[2.33.0,3.0.0)";visibility:=reexport
+ org.eclipse.emf.ecore;bundle-version="[2.35.0,3.0.0)";visibility:=reexport
 Import-Package: javax.xml.namespace,
  javax.xml.parsers,
  org.osgi.framework;version="[1.5.0,2.0.0)",

--- a/plugins/org.eclipse.emf.ecore.xmi/pom.xml
+++ b/plugins/org.eclipse.emf.ecore.xmi/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>org.eclipse.emf</groupId>
   <artifactId>org.eclipse.emf.ecore.xmi</artifactId>
-  <version>2.18.0-SNAPSHOT</version>
+  <version>2.35.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
 </project>

--- a/plugins/org.eclipse.emf.ecore.xmi/src/org/eclipse/emf/ecore/xmi/XMLResource.java
+++ b/plugins/org.eclipse.emf.ecore.xmi/src/org/eclipse/emf/ecore/xmi/XMLResource.java
@@ -563,6 +563,13 @@ public interface XMLResource extends Resource
    */
   String OPTION_MISSING_PACKAGE_HANDLER = "MISSING_PACKAGE_HANDLER";
 
+  /**
+   * A load option that specifies whether external entities should be resolved during XML loading.
+   * The default value is false.
+   * @since 2.35
+   */
+  String OPTION_RESOLVE_ENTITIES = "RESOLVED_ENTITIES";
+
   String HREF = "href";
   String NIL = "nil";
   String TYPE = "type";

--- a/plugins/org.eclipse.emf.ecore.xmi/src/org/eclipse/emf/ecore/xmi/impl/XMLHandler.java
+++ b/plugins/org.eclipse.emf.ecore.xmi/src/org/eclipse/emf/ecore/xmi/impl/XMLHandler.java
@@ -14,6 +14,7 @@ package org.eclipse.emf.ecore.xmi.impl;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.StringReader;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -346,6 +347,11 @@ public abstract class XMLHandler extends DefaultHandler implements XMLDefaultHan
   protected XMLResource.MissingPackageHandler missingPackageHandler;
 
   /**
+   * @since 2.35
+   */
+  protected boolean resolveEntities;
+
+  /**
    */
   public XMLHandler(XMLResource xmlResource, XMLHelper helper, Map<?, ?> options)
   {
@@ -509,6 +515,7 @@ public abstract class XMLHandler extends DefaultHandler implements XMLDefaultHan
 
     usePackageNsURIAsLocation = !Boolean.FALSE.equals(options.get(XMLResource.OPTION_USE_PACKAGE_NS_URI_AS_LOCATION));
     missingPackageHandler = (XMLResource.MissingPackageHandler)options.get(XMLResource.OPTION_MISSING_PACKAGE_HANDLER);
+    resolveEntities = Boolean.TRUE.equals(options.get(XMLResource.OPTION_RESOLVE_ENTITIES));
   }
 
   protected void setExtendedMetaDataOption(Object extendedMetaDataOption)
@@ -804,6 +811,11 @@ public abstract class XMLHandler extends DefaultHandler implements XMLDefaultHan
   @Override
   public InputSource resolveEntity(String publicId, String systemId) throws SAXException
   {
+    if (!resolveEntities)
+    {
+      return new InputSource(new StringReader("")); //$NON-NLS-1$
+    }
+
     try
     {
       Map<Object, Object> options = new HashMap<Object, Object>();

--- a/tests/org.eclipse.emf.test.xml/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.emf.test.xml/META-INF/MANIFEST.MF
@@ -2,21 +2,21 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.emf.test.xml;singleton:=true
-Bundle-Version: 2.15.0.qualifier
+Bundle-Version: 2.16.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
-Export-Package: org.eclipse.emf.test.xml;version="2.15.0",
- org.eclipse.emf.test.xml.encoding;version="2.15.0",
- org.eclipse.emf.test.xml.rss;version="2.15.0",
- org.eclipse.emf.test.xml.xmi;version="2.15.0",
- org.eclipse.emf.test.xml.xsd;version="2.15.0",
- org.eclipse.emf.test.xml.xsdecore;version="2.15.0"
+Export-Package: org.eclipse.emf.test.xml;version="2.16.0",
+ org.eclipse.emf.test.xml.encoding;version="2.16.0",
+ org.eclipse.emf.test.xml.rss;version="2.16.0",
+ org.eclipse.emf.test.xml.xmi;version="2.16.0",
+ org.eclipse.emf.test.xml.xsd;version="2.16.0",
+ org.eclipse.emf.test.xml.xsdecore;version="2.16.0"
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.9.0,4.0.0)",
  org.eclipse.core.resources;bundle-version="[3.8.0,4.0.0)",
- org.eclipse.emf.ecore;bundle-version="[2.33.0,3.0.0)",
- org.eclipse.emf.ecore.xmi;bundle-version="[2.18.0,3.0.0)",
+ org.eclipse.emf.ecore;bundle-version="[2.35.0,3.0.0)",
+ org.eclipse.emf.ecore.xmi;bundle-version="[2.35.0,3.0.0)",
  org.eclipse.xsd;bundle-version="[2.19.0,3.0.0)",
  org.junit;bundle-version="[4.12.0,5.0.0)",
  org.eclipse.emf.test.common;bundle-version="[1.11.0,2.0.0)"

--- a/tests/org.eclipse.emf.test.xml/data/xmi/root.dtd
+++ b/tests/org.eclipse.emf.test.xml/data/xmi/root.dtd
@@ -1,0 +1,1 @@
+<!ELEMENT root (#PCDATA)>

--- a/tests/org.eclipse.emf.test.xml/data/xmi/test-with-external-entity.xmi
+++ b/tests/org.eclipse.emf.test.xml/data/xmi/test-with-external-entity.xmi
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE root SYSTEM "root.dtd">
+<root/>

--- a/tests/org.eclipse.emf.test.xml/pom.xml
+++ b/tests/org.eclipse.emf.test.xml/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>org.eclipse.emf</groupId>
   <artifactId>org.eclipse.emf.test.xml</artifactId>
-  <version>2.15.0-SNAPSHOT</version>
+  <version>2.16.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
 </project>

--- a/tests/org.eclipse.emf.test.xml/src/org/eclipse/emf/test/xml/DTDTest.java
+++ b/tests/org.eclipse.emf.test.xml/src/org/eclipse/emf/test/xml/DTDTest.java
@@ -45,6 +45,7 @@ public class DTDTest
   public void setUp() throws Exception
   {
     resourceSet = new ResourceSetImpl();
+    resourceSet.getLoadOptions().put(XMLResource.OPTION_RESOLVE_ENTITIES, Boolean.TRUE);
     resourceSet.getResourceFactoryRegistry().getExtensionToFactoryMap().put
       (Resource.Factory.Registry.DEFAULT_EXTENSION, new GenericXMLResourceFactoryImpl());
   }


### PR DESCRIPTION
This option is false by default and will prevent XMLHandler.resolveEntity(String, String) from loading external entities.

https://github.com/eclipse-emf/org.eclipse.emf/issues/10