### PR TITLE
Remove re-export of org.apache.log4j bundle from emf.ecore.xcore

### DIFF
--- a/plugins/org.eclipse.emf.ecore.xcore/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.ecore.xcore/META-INF/MANIFEST.MF
@@ -9,7 +9,6 @@ Bundle-SymbolicName: org.eclipse.emf.ecore.xcore;singleton:=true
 Bundle-Activator: org.eclipse.emf.ecore.xcore.XcorePlugin$Implementation
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext;bundle-version="[2.13.0,3.0.0)";visibility:=reexport,
- org.apache.log4j;bundle-version="[1.2.0,2.0.0)";visibility:=reexport,
  org.eclipse.emf.ecore;bundle-version="[2.35.0,3.0.0)";visibility:=reexport,
  org.eclipse.xtext.util;bundle-version="[2.18.0,3.0.0)",
  org.antlr.runtime;bundle-version="[3.2.0,3.2.1)",


### PR DESCRIPTION
Requiring the bundle `org.apache.log4j` forces the actual `org.apache.log4j` bundle in applications that contain `emf.ecore.xcore` and makes it impossible to bridge/redirect to other logging back-ends.

In general this has the potential to break existing plugins that require emf.ecore.xcore and don't import or require log4j by themself.
@merks can you assess if there are relevant cases for that or if that is only hypothetical?
In Xtext there was a little 'poll' how important backwards compatibility in this area: https://github.com/eclipse/xtext/issues/2668