### PR TITLE
Remove org.apache.log4j from emf.ecore.xcore features

### DIFF
--- a/features/org.eclipse.emf.ecore.xcore-feature/feature.xml
+++ b/features/org.eclipse.emf.ecore.xcore-feature/feature.xml
@@ -30,13 +30,11 @@ http://www.eclipse.org/legal/epl-v20.html
 
    <requires>
       <import plugin="org.eclipse.xtext"/>
-      <import plugin="org.apache.log4j"/>
       <import plugin="org.eclipse.emf.ecore"/>
       <import plugin="org.eclipse.xtext.util"/>
       <import plugin="org.antlr.runtime"/>
       <import plugin="org.eclipse.xtext.xbase"/>
       <import plugin="org.eclipse.xtext.common.types"/>
-      <import plugin="org.apache.commons.logging"/>
       <import plugin="org.eclipse.xtext.xbase.lib"/>
       <import plugin="org.eclipse.emf.codegen.ecore"/>
       <import plugin="org.eclipse.core.runtime"/>

--- a/features/org.eclipse.emf.ecore.xcore.ui-feature/feature.xml
+++ b/features/org.eclipse.emf.ecore.xcore.ui-feature/feature.xml
@@ -48,7 +48,6 @@ http://www.eclipse.org/legal/epl-v20.html
       <import plugin="org.eclipse.emf.ecore.editor"/>
       <import plugin="org.eclipse.jdt.core"/>
       <import plugin="org.eclipse.emf.codegen.ecore.ui"/>
-      <import plugin="org.apache.log4j"/>
       <import plugin="org.eclipse.emf.codegen.ecore.xtext"/>
    </requires>
 

--- a/releng/org.eclipse.emf.releng/publish/aggr/EMF.aggr
+++ b/releng/org.eclipse.emf.releng/publish/aggr/EMF.aggr
@@ -59,7 +59,6 @@
       <mavenMappings namePattern="org.eclipse.ant.core" groupId="org.eclipse.platform" artifactId="org.eclipse.ant.core"/>
       <mavenMappings namePattern="org.eclipse.debug.(.*)" groupId="org.eclipse.platform" artifactId="org.eclipse.debug.$1"/>
       <mavenMappings namePattern="org.eclipse.core.(.*)" groupId="org.eclipse.platform" artifactId="org.eclipse.core.$1"/>
-      <mavenMappings namePattern="org.apache.log4j" groupId="log4j" artifactId="log4j"/>
       <mavenMappings namePattern="org.antlr.runtime" groupId="org.antlr" artifactId="antlr-runtime" versionPattern="3.2" versionTemplate=".*"/>
       <mavenMappings namePattern="org.objectweb.asm" groupId="org.ow2.asm" artifactId="asm"/>
     </contributions>


### PR DESCRIPTION
Follow-up on https://github.com/eclipse-emf/org.eclipse.emf/pull/15.

Importing the bundle org.apache.log4j forces the actual org.apache.log4j bundle in applications that maybe use a bridge/redirection to another logging back-end and thus don't use the org.apache.log4j bundle to provide the log4j-1 API.
If necessary org.apache.log4j is pulled in as transitive dependency anyways.

Additionally this removes the `mavenMappings` for log4j-1 from the `EMF.aggr` or is this still relevant?