### PR TITLE
Migrate from log4j-1 to slf4j and remove unnecessary logging imports

### DIFF
--- a/plugins/org.eclipse.emf.codegen.ecore.xtext.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.codegen.ecore.xtext.ui/META-INF/MANIFEST.MF
@@ -4,16 +4,16 @@ Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.emf.codegen.ecore.xtext.ui;singleton:=true
-Bundle-Version: 1.5.0.qualifier
-Require-Bundle: org.eclipse.emf.codegen.ecore.xtext;bundle-version="[1.7.0,2.0.0)",
- org.eclipse.emf.codegen.ecore.ui;bundle-version="[2.33.0,3.0.0)",
+Bundle-Version: 1.6.0.qualifier
+Require-Bundle: org.eclipse.emf.codegen.ecore.xtext;bundle-version="[1.8.0,2.0.0)",
+ org.eclipse.emf.codegen.ecore.ui;bundle-version="[2.36.0,3.0.0)",
  org.eclipse.xtext.ui;bundle-version="[2.18.0,3.0.0)",
  org.eclipse.xtext.ui.shared;bundle-version="[2.18.0,3.0.0)",
  org.eclipse.jdt.core;bundle-version="[3.9.0,4.0.0)",
  org.eclipse.jdt.ui;bundle-version="[3.6.0,4.0.0)"
-Import-Package: org.apache.log4j;version="[1.2.0,2.0.0)"
+Import-Package: org.slf4j;version="[1.7.0,3.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.eclipse.emf.codegen.ecore.xtext.ui.Activator
-Export-Package: org.eclipse.emf.codegen.ecore.xtext.ui;version="1.5.0"
+Export-Package: org.eclipse.emf.codegen.ecore.xtext.ui;version="1.6.0"
 Automatic-Module-Name: org.eclipse.emf.codegen.ecore.xtext.ui

--- a/plugins/org.eclipse.emf.codegen.ecore.xtext.ui/pom.xml
+++ b/plugins/org.eclipse.emf.codegen.ecore.xtext.ui/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>org.eclipse.emf</groupId>
   <artifactId>org.eclipse.emf.codegen.ecore.xtext.ui</artifactId>
-  <version>1.5.0-SNAPSHOT</version>
+  <version>1.6.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
 </project>

--- a/plugins/org.eclipse.emf.codegen.ecore.xtext.ui/src/org/eclipse/emf/codegen/ecore/xtext/ui/Activator.java
+++ b/plugins/org.eclipse.emf.codegen.ecore.xtext.ui/src/org/eclipse/emf/codegen/ecore/xtext/ui/Activator.java
@@ -8,11 +8,12 @@
 package org.eclipse.emf.codegen.ecore.xtext.ui;
 
 
-import org.apache.log4j.Logger;
 import org.eclipse.emf.codegen.ecore.xtext.GenModelRuntimeModule;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.eclipse.xtext.ui.shared.SharedStateModule;
 import org.osgi.framework.BundleContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -25,7 +26,7 @@ import com.google.inject.util.Modules;
 public class Activator extends AbstractUIPlugin
 {
 
-  private static final Logger logger = Logger.getLogger(Activator.class);
+  private static final Logger logger = LoggerFactory.getLogger(Activator.class);
 
   // The plug-in ID
   public static final String PLUGIN_ID = "org.eclipse.emf.codegen.ecore.xtext.ui"; //$NON-NLS-1$

--- a/plugins/org.eclipse.emf.codegen.ecore.xtext/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.codegen.ecore.xtext/META-INF/MANIFEST.MF
@@ -1,15 +1,14 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.emf.codegen.ecore.xtext;singleton:=true
-Bundle-Version: 1.7.0.qualifier
-Require-Bundle: org.eclipse.emf.codegen.ecore;bundle-version="[2.33.0,3.0.0)",
+Bundle-Version: 1.8.0.qualifier
+Require-Bundle: org.eclipse.emf.codegen.ecore;bundle-version="[2.36.0,3.0.0)",
  org.eclipse.xtext;bundle-version="[2.18.0,3.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.9.0,4.0.0)",
  org.eclipse.emf.mwe2.runtime;bundle-version="[2.9.0,3.0.0)"
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-Name: %pluginName
-Import-Package: org.apache.log4j;version="[1.2.0,2.0.0)"
-Export-Package: org.eclipse.emf.codegen.ecore.xtext;version="1.7.0"
+Export-Package: org.eclipse.emf.codegen.ecore.xtext;version="1.8.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Automatic-Module-Name: org.eclipse.emf.codegen.ecore.xtext

--- a/plugins/org.eclipse.emf.codegen.ecore.xtext/pom.xml
+++ b/plugins/org.eclipse.emf.codegen.ecore.xtext/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>org.eclipse.emf</groupId>
   <artifactId>org.eclipse.emf.codegen.ecore.xtext</artifactId>
-  <version>1.7.0-SNAPSHOT</version>
+  <version>1.8.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
 </project>

--- a/plugins/org.eclipse.emf.ecore.xcore.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.ecore.xcore.ui/META-INF/MANIFEST.MF
@@ -25,7 +25,7 @@ Require-Bundle: org.eclipse.ui;bundle-version="[3.105.0,4.0.0)",
  org.eclipse.emf.ecore.editor;bundle-version="[2.18.0,3.0.0)",
  org.eclipse.jdt.core;bundle-version="[3.9.0,4.0.0)",
  org.eclipse.emf.codegen.ecore.ui;bundle-version="[2.36.0,3.0.0)",
- org.eclipse.emf.codegen.ecore.xtext.ui;bundle-version="[1.5.0,2.0.0)",
+ org.eclipse.emf.codegen.ecore.xtext.ui;bundle-version="[1.6.0,2.0.0)",
  org.eclipse.debug.ui;bundle-version="[3.6.0,4.0.0)",
  org.eclipse.jdt.ui;bundle-version="[3.6.0,4.0.0)",
  org.eclipse.jdt.core.manipulation;bundle-version="[1.3.0,2.0.0)",
@@ -52,6 +52,6 @@ Export-Package: org.eclipse.emf.ecore.xcore.ui;version="1.26.0",
  org.eclipse.emf.xcore.ui.folding;version="1.26.0",
  org.eclipse.emf.ecore.xcore.ide.contentassist.antlr;version="1.26.0",
  org.eclipse.emf.ecore.xcore.ide.contentassist.antlr.internal;version="1.26.0"
-Import-Package: org.apache.log4j;version="[1.2.0,2.0.0)",
- org.eclipse.xtext.xbase.lib;version="[2.13.0,3.0.0)"
+Import-Package: org.eclipse.xtext.xbase.lib;version="[2.13.0,3.0.0)",
+ org.slf4j;version="[1.7.0,3.0.0)"
 Automatic-Module-Name: org.eclipse.emf.ecore.xcore.ui

--- a/plugins/org.eclipse.emf.ecore.xcore.ui/src-gen/org/eclipse/emf/ecore/xcore/ui/internal/XcoreActivator.java
+++ b/plugins/org.eclipse.emf.ecore.xcore.ui/src-gen/org/eclipse/emf/ecore/xcore/ui/internal/XcoreActivator.java
@@ -8,13 +8,14 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import java.util.Collections;
 import java.util.Map;
-import org.apache.log4j.Logger;
 import org.eclipse.emf.ecore.xcore.XcoreRuntimeModule;
 import org.eclipse.emf.ecore.xcore.ui.XcoreUiModule;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.eclipse.xtext.ui.shared.SharedStateModule;
 import org.eclipse.xtext.util.Modules2;
 import org.osgi.framework.BundleContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class was generated. Customizations should only happen in a newly
@@ -25,7 +26,7 @@ public class XcoreActivator extends AbstractUIPlugin {
 	public static final String PLUGIN_ID = "org.eclipse.emf.ecore.xcore.ui";
 	public static final String ORG_ECLIPSE_EMF_ECORE_XCORE_XCORE = "org.eclipse.emf.ecore.xcore.Xcore";
 	
-	private static final Logger logger = Logger.getLogger(XcoreActivator.class);
+	private static final Logger logger = LoggerFactory.getLogger(XcoreActivator.class);
 	
 	private static XcoreActivator INSTANCE;
 	

--- a/plugins/org.eclipse.emf.ecore.xcore.ui/src/org/eclipse/emf/ecore/xcore/ui/quickfix/XcoreClasspathUpdater.java
+++ b/plugins/org.eclipse.emf.ecore.xcore.ui/src/org/eclipse/emf/ecore/xcore/ui/quickfix/XcoreClasspathUpdater.java
@@ -20,7 +20,6 @@ import java.net.URL;
 import java.util.Collections;
 import java.util.Set;
 
-import org.apache.log4j.Logger;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
@@ -41,11 +40,13 @@ import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 import org.osgi.framework.Bundle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class XcoreClasspathUpdater
 {
-  private static final Logger LOG = Logger.getLogger(XcoreClasspathUpdater.class);
+  private static final Logger LOG = LoggerFactory.getLogger(XcoreClasspathUpdater.class);
 
   private static final String PLUGIN_NATURE = "org.eclipse.pde.PluginNature";
 

--- a/plugins/org.eclipse.emf.ecore.xcore/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emf.ecore.xcore/META-INF/MANIFEST.MF
@@ -18,11 +18,10 @@ Require-Bundle: org.eclipse.xtext;bundle-version="[2.13.0,3.0.0)";visibility:=re
  org.eclipse.core.runtime;bundle-version="[3.9.0,4.0.0)",
  org.eclipse.xtext.ecore;bundle-version="[2.18.0,3.0.0)";visibility:=reexport,
  org.eclipse.emf.ecore.xcore.lib;bundle-version="[1.7.0,2.0.0)";visibility:=reexport,
- org.eclipse.emf.codegen.ecore.xtext;bundle-version="[1.7.0,2.0.0)";visibility:=reexport,
+ org.eclipse.emf.codegen.ecore.xtext;bundle-version="[1.8.0,2.0.0)";visibility:=reexport,
  org.eclipse.emf.codegen.ecore;bundle-version="[2.36.0,3.0.0)",
  org.objectweb.asm;bundle-version="[5.0.0,11.0.0)";resolution:=optional
-Import-Package: org.apache.commons.logging;version="[1.0.0,2.0.0)",
- org.apache.log4j;version="[1.2.0,2.0.0)"
+Import-Package: org.slf4j;version="[1.7.0,3.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.emf.ecore.xcore;version="1.27.0",
  org.eclipse.emf.ecore.xcore.conversion;version="1.27.0",

--- a/plugins/org.eclipse.emf.ecore.xcore/src/org/eclipse/emf/ecore/xcore/validation/XcoreResourceValidator.java
+++ b/plugins/org.eclipse.emf.ecore.xcore/src/org/eclipse/emf/ecore/xcore/validation/XcoreResourceValidator.java
@@ -10,7 +10,6 @@ package org.eclipse.emf.ecore.xcore.validation;
 
 import java.util.Map;
 
-import org.apache.log4j.Logger;
 import org.eclipse.emf.common.notify.Adapter;
 import org.eclipse.emf.common.notify.impl.AdapterImpl;
 import org.eclipse.emf.common.util.BasicDiagnostic;
@@ -33,6 +32,8 @@ import org.eclipse.xtext.validation.Issue;
 import org.eclipse.xtext.validation.ResourceValidatorImpl;
 import org.eclipse.xtext.validation.impl.ConcreteSyntaxEValidator;
 import org.eclipse.xtext.xbase.annotations.validation.DerivedStateAwareResourceValidator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Maps;
 import com.google.inject.Inject;
@@ -45,7 +46,7 @@ public class XcoreResourceValidator extends DerivedStateAwareResourceValidator
     public abstract void update(Diagnostic diagnostic);
   }
 
-  private static final Logger log = Logger.getLogger(ResourceValidatorImpl.class);
+  private static final Logger log = LoggerFactory.getLogger(ResourceValidatorImpl.class);
 
   @Inject
   private Diagnostician diagnostician;

--- a/tests/org.eclipse.emf.test.ecore.xcore/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.emf.test.ecore.xcore/META-INF/MANIFEST.MF
@@ -21,14 +21,12 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.9.0,4.0.0)";resoluti
  org.eclipse.xtext.ui.testing;bundle-version="[2.18.0,3.0.0)",
  org.eclipse.ui.workbench;resolution:=optional;bundle-version="[3.6.0,4.0.0)",
  org.eclipse.xtext.xbase.junit;bundle-version="[2.18.0,3.0.0)"
-Import-Package: org.apache.commons.logging;version="[1.0.0,2.0.0)",
- org.apache.log4j;version="[1.2.0,2.0.0)",
+Import-Package: org.hamcrest.core;version="[1.3.0,3.0.0)",
  org.junit.runner;version="[4.12.0,5.0.0)",
  org.junit.runner.manipulation;version="[4.12.0,5.0.0)",
  org.junit.runner.notification;version="[4.12.0,5.0.0)",
  org.junit.runners;version="[4.12.0,5.0.0)",
- org.junit.runners.model;version="[4.12.0,5.0.0)",
- org.hamcrest.core;version="[1.3.0,3.0.0)"
+ org.junit.runners.model;version="[4.12.0,5.0.0)"
 Export-Package: org.eclipse.emf.test.ecore.xcore;version="1.26.0",
  org.eclipse.emf.test.ecore.xcore.ecore;version="1.26.0",
  org.eclipse.emf.test.ecore.xcore.generator;version="1.26.0",


### PR DESCRIPTION
Log4J-1 used to be EOL, now it has been revived with reload4j, but nevertheless I think it is better to use a more active logging facade like slf4j.
If you prefer log4j-2 would also be possible but I haven't checked yet if it log4j-2 API is available in the TP.

Importing org.apache.commons.logging was not necessary. Probably it was generated by XText.
In this sense another remark: AFAIK Xtext currently still generates log4j-1 dependencies even for new projects, so in case the project is regenerated this should probably be considered.