### PR TITLE
Default values for EAttributes with generics is not generated #22

### DIFF
--- a/plugins/org.eclipse.emf.codegen.ecore/src/org/eclipse/emf/codegen/ecore/genmodel/impl/GenFeatureImpl.java
+++ b/plugins/org.eclipse.emf.codegen.ecore/src/org/eclipse/emf/codegen/ecore/genmodel/impl/GenFeatureImpl.java
@@ -2600,6 +2600,7 @@ public class GenFeatureImpl extends GenTypedElementImpl implements GenFeature
     return 
       getEcoreFeature() instanceof EAttribute && 
         (getEffectiveComplianceLevel().getValue() < GenJDKLevel.JDK50 ||
+           ((EAttribute)getEcoreFeature()).getDefaultValueLiteral() != null ||
            (getEcoreFeature().getEType() != null &&
                getEcoreFeature().getEType().getETypeParameters().isEmpty() && 
                getEcoreFeature().getEGenericType().getETypeParameter() == null &&


### PR DESCRIPTION
GenFeature.hasEDefault() will now  also return true for all EAttributes that has a non-null default value literal