### PR TITLE
Default values for generic EAttributes isn't casted to target type #25

### DIFF
--- a/plugins/org.eclipse.emf.codegen.ecore/src/org/eclipse/emf/codegen/ecore/genmodel/impl/GenFeatureImpl.java
+++ b/plugins/org.eclipse.emf.codegen.ecore/src/org/eclipse/emf/codegen/ecore/genmodel/impl/GenFeatureImpl.java
@@ -1400,7 +1400,11 @@ public class GenFeatureImpl extends GenTypedElementImpl implements GenFeature
     if (eType instanceof EDataType)
     {
       GenDataType genDataType = (GenDataType)findGenClassifier(eType);
-      return genDataType.getStaticValue(defaultString);
+      if (hasGenericType()) {
+        return getRawTypeCast() + genDataType.getStaticValue(defaultString, false);
+      } else {
+        return genDataType.getStaticValue(defaultString);
+      }
     }
 
     return "null";

--- a/plugins/org.eclipse.emf.codegen.ecore/src/org/eclipse/emf/codegen/ecore/genmodel/impl/GenFeatureImpl.java
+++ b/plugins/org.eclipse.emf.codegen.ecore/src/org/eclipse/emf/codegen/ecore/genmodel/impl/GenFeatureImpl.java
@@ -1400,9 +1400,12 @@ public class GenFeatureImpl extends GenTypedElementImpl implements GenFeature
     if (eType instanceof EDataType)
     {
       GenDataType genDataType = (GenDataType)findGenClassifier(eType);
-      if (hasGenericType()) {
+      if (hasGenericType())
+      {
         return getRawTypeCast() + genDataType.getStaticValue(defaultString, false);
-      } else {
+      }
+      else
+      {
         return genDataType.getStaticValue(defaultString);
       }
     }


### PR DESCRIPTION
GenFeature.getStaticDefaultValue() now checks if the type is generic and if so, adds a cast to the raw type of the feature instead of the EDataType's type.
