### PR TITLE
resolve EClass of DyanmicEObject if eClass is proxy

### DIFF
--- a/plugins/org.eclipse.emf.ecore/src/org/eclipse/emf/ecore/impl/DynamicEObjectImpl.java
+++ b/plugins/org.eclipse.emf.ecore/src/org/eclipse/emf/ecore/impl/DynamicEObjectImpl.java
@@ -21,6 +21,7 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EOperation;
 import org.eclipse.emf.ecore.EStructuralFeature;
 import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.util.EcoreUtil;
 
 
 /**
@@ -278,6 +279,11 @@ public class DynamicEObjectImpl extends EObjectImpl implements EStructuralFeatur
   @Override
   public EClass eClass()
   {
+    if(eClass.eIsProxy()) 
+    {
+      eClass = (EClass) EcoreUtil.resolve(eClass, this);
+    }
+    
     return eClass;
   }
 


### PR DESCRIPTION
If a dynamically loaded EPackage is unloaded and then reloaded, the Class becomes a Proxy. Independetly loaded DynamicEObjects will then return detached and out of date EClasses, which can cause a lot of issues, as normally nobody will expect this. With this, we at least make an effort to resolve the Proxy. If the new Version of the EClass is too different, this will cause Errors, but then you are in world of self inflicted Pain anyway.

@merks Not to stress you, but maybe this can make it in the next RC :-)